### PR TITLE
Fixes #58 Build link was not attached to work item

### DIFF
--- a/src/WorkItemUpdater/WorkItemUpdater.ts
+++ b/src/WorkItemUpdater/WorkItemUpdater.ts
@@ -258,7 +258,7 @@ async function updateWorkItem(workItemTrackingClient: IWorkItemTrackingApi, work
         if (settings.linkBuild) {
             const buildRelationUrl = 'vstfs:///Build/Build/$buildId';
             const buildRelation = !workItem.relations || workItem.relations.find(r => r.url === buildRelationUrl);
-            if (buildRelation === null) {
+            if (buildRelation === undefined) {
                 console.log('Linking Build ' + settings.buildId + ' to WorkItem ' + workItem.id);
                 const relation: WorkItemRelation = {
                     rel: 'ArtifactLink',
@@ -321,6 +321,13 @@ async function updateWorkItem(workItemTrackingClient: IWorkItemTrackingApi, work
         }
 
         tl.debug('Start UpdateWorkItem');
+
+        if(document.length === 0) {
+            // workItemTrackingClient.updateWorkItem fails if there is not patch operation
+            console.log('No update for WorkItem ' + workItem.id);
+            return false;
+        }
+
         const updatedWorkItem = await workItemTrackingClient.updateWorkItem(
             undefined,
             document,


### PR DESCRIPTION
This pull request fixes #58.

The build link is not attached because of a bad condition. I was not able to test the task itself but I reproduced it [here](https://www.typescriptlang.org/play/index.html#code/MYewdgzgLgBA7iATgawJJQKYFsYF4YDeAsAFAzkyIYA2AhlAJbgQBcMA2gES2cC6pAX1KhIsBCnTYATHkKkKlGvSaQ2YAK7Vqg0qWogA5gCUMETVAAU4tJiwAaGN04BKANx7DJs9UvXJ9xwAjF3cSfWNTcyskG2kHJzddEgAzdTBgRnAYcK8ov1s2WjAATwcAN1pqdQw2aEQGMANnOTIKCsRFb1h8AEJ87AA6KjpMyBgAH3H4GP8hpVGIAeSGgBMLDtwAPko8XHwKqoxE1vJ2zvMZfHXIn138DS1j+QoRCBBqDAHw667jhVf3p9vlQulJjgIgA).

The function `array.find` returns `undefined`: https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/Array/find

I also added a guard before updating the work item. If there is no change to the work item it won't perform the update.