### PR TITLE
Fixes #63 Set the actual build number in the build link

### DIFF
--- a/src/WorkItemUpdater/WorkItemUpdater.ts
+++ b/src/WorkItemUpdater/WorkItemUpdater.ts
@@ -256,7 +256,7 @@ async function updateWorkItem(workItemTrackingClient: IWorkItemTrackingApi, work
         }
 
         if (settings.linkBuild) {
-            const buildRelationUrl = 'vstfs:///Build/Build/$buildId';
+            const buildRelationUrl = `vstfs:///Build/Build/${settings.buildId}`;
             const buildRelation = !workItem.relations || workItem.relations.find(r => r.url === buildRelationUrl);
             if (buildRelation === null) {
                 console.log('Linking Build ' + settings.buildId + ' to WorkItem ' + workItem.id);


### PR DESCRIPTION
Assuming that the URL "vstfs:///Build/Build/123" is the correct URL to identify a build, it should fix the issue.