### PR TITLE
add option to set Assigned To to Activated By

### DIFF
--- a/src/WorkItemUpdater/WorkItemUpdater.ts
+++ b/src/WorkItemUpdater/WorkItemUpdater.ts
@@ -35,9 +35,13 @@ async function main(): Promise<void> {
 
                 switch (settings.updateAssignedToWith) {
                     case 'Creator': {
-                        const creator = workItem.fields['System.CreatedBy'];
-                        tl.debug('Using workitem creator user "' + creator + '" as assignedTo.');
-                        settings.assignedTo = creator;
+                        settings.assignedTo = workItem.fields['System.CreatedBy'];
+                        tl.debug('Using workitem creator user "' + settings.assignedTo + '" as assignedTo.');
+                        break;
+                    }
+                    case 'ActivatedBy': {
+                        settings.assignedTo = workItem.fields['Microsoft.VSTS.Common.ActivatedBy'];
+                        tl.debug('Using workitem activator user "' + settings.assignedTo + '" as assignedTo.');
                         break;
                     }
                     case 'FixedUser': {

--- a/src/WorkItemUpdater/task.json
+++ b/src/WorkItemUpdater/task.json
@@ -12,8 +12,8 @@
     ],
     "version": {
         "Major": "2",
-        "Minor": "3",
-        "Patch": "765"
+        "Minor": "5",
+        "Patch": "800"
     },
     "demands": [],
     "minimumAgentVersion": "1.91.0",
@@ -156,6 +156,7 @@
             "options": {
                 "Requester": "Requester of the build",
                 "Creator": "Creator of the workitem",
+                "ActivatedBy": "User who started the item",
                 "FixedUser": "Fixed user",
                 "Unassigned": "Unassign the workitem"
             }

--- a/src/overview.md
+++ b/src/overview.md
@@ -20,6 +20,8 @@ A preview of what the task can do, can be seen in this recording:
 ![settings](img/Settings.png)  
   
 ## Version History
+### 2.5.800
+- Update 'Assigned To' with option for Activated By user
 ### 2.5.793
 - Functionality to add custom list of Fields to update 
 - Functionality to allow to bypass workitem type rules 


### PR DESCRIPTION
v 2.5.800

Add an option to assign the work item to the person who set the item to In Progress, or Activated By, as documented [here](https://docs.microsoft.com/en-us/azure/devops/boards/queries/query-by-workflow-changes?view=azure-devops#workflow-and-kanban-board-fields).