### PR TITLE
Update WorkItemUpdater.ts - bugfix remove tags functionality

### DIFF
--- a/src/WorkItemUpdater/WorkItemUpdater.ts
+++ b/src/WorkItemUpdater/WorkItemUpdater.ts
@@ -286,9 +286,13 @@ async function updateWorkItem(workItemTrackingClient: IWorkItemTrackingApi, work
         }
 
         if (settings.addTags || settings.removeTags) {
+            let operation: Operation = Operation.Add;
             const newTags: string[] = [];
 
             const removeTags: string[] = settings.removeTags ? settings.removeTags.split(';') : [];
+            
+            if (removeTags.length > 0) operation = Operation.Replace;
+            
             if (workItem.fields['System.Tags']) {
                 tl.debug('Existing tags: ' + workItem.fields['System.Tags']);
                 workItem.fields['System.Tags'].split(';').forEach((tag: string) => {
@@ -309,7 +313,7 @@ async function updateWorkItem(workItemTrackingClient: IWorkItemTrackingApi, work
                 }
             });
 
-            addPatchOperation('/fields/System.Tags', newTags.join('; '), document);
+            addPatchOperation('/fields/System.Tags', newTags.join('; '), document, operation);
         }
 
         if (settings.updateFields) {


### PR DESCRIPTION
- I tried to use the WorkItemUpdater to add at linked build work items each on the one hand a tag like 'deployed_to_production'  and to remove a tag like 'deployed_to_test' on the other hand.

- The logs told me that it would do it, but the system was shown both tags afterwards.

- After some debugging rounds I found out that with patch parameter 'add', which was used here by default,
one can only add tags to Azure Devops work items but not delete any of them.

- Because of that when you want to delete tags from work items, you need to use the patch parameter 'replace' instead.

- So with this pull request I adjusted the WorkItemUpdater.ts, so that the patch operation parameter 'replace' is used, when there are tags that should be removed.