### PR TITLE
Fixed passing "bypass rules" to the TFS/Azure DevOps API

### DIFF
--- a/src/WorkItemUpdater/WorkItemUpdater.ts
+++ b/src/WorkItemUpdater/WorkItemUpdater.ts
@@ -363,6 +363,7 @@ async function updateWorkItem(workItemTrackingClient: IWorkItemTrackingApi, work
                 document,
                 workItem.id,
                 undefined,
+				false,
                 settings.bypassRules);
             console.log('WorkItem ' + workItem.id + ' updated');
         }


### PR DESCRIPTION
Fixed saving changes to work items when the "bypass rules" checkbox is selected.

Added `false` as the value for the `validateOnly` parameter in `workItemTrackingClient.updateWorkItem(...)` so that `settings.bypassRules` is passed in as the `bypassRules` parameter instead of the `validateOnly` parameter.