### PR TITLE
Use correct version for task.json

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           file: src/task.json
           field: version.Patch
-          value: ${{ steps.gitversion.outputs.patch }}
+          value: ${{ steps.gitversion.outputs.commitsSinceVersionSource }}
           
       - name: Npm compile
         run: npm run compile

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "tfx-cli": "^0.9.3",
     "tslint": "^6.1.3",
     "typescript": "4.4.4",
-    "rimraf": "^3.0.2"
+    "rimraf": "^3.0.2",
+    "azp-bump": "2.0.15"
   },
   "name": "vstsexttask",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "tfx-cli": "^0.9.3",
     "tslint": "^6.1.3",
     "typescript": "4.4.4",
-    "rimraf": "^3.0.2",
-    "azp-bump": "2.0.15"
+    "rimraf": "^3.0.2"
   },
   "name": "vstsexttask",
   "private": true,


### PR DESCRIPTION
The task.json was net updated correctly, resulting in the patch version never to be increased. Because of this Azure DevOps would not use a newer version of the task. This PR fixes that bug.