### PR TITLE
#62 fixing work item search with multiple artifacts

### DIFF
--- a/src/WorkItemUpdater.ts
+++ b/src/WorkItemUpdater.ts
@@ -185,7 +185,7 @@ async function getWorkItemsRefs(vstsWebApi: WebApi, workItemTrackingClient: IWor
 
 async function getBuildOrReleaseWorkItemsRefs(vstsWebApi: WebApi, settings: Settings): Promise<ResourceRef[]> {
     const buildClient: IBuildApi = await vstsWebApi.getBuildApi();
-    var workItemRefs: ResourceRef[] = [];
+    let workItemRefs: ResourceRef[] = [];
 
     if (settings.releaseId) {
         console.log('Using Release as WorkItem Source');
@@ -207,7 +207,7 @@ async function getBuildOrReleaseWorkItemsRefs(vstsWebApi: WebApi, settings: Sett
             }
         } else {
             for (const currentArtifact of currentRelease.artifacts) {
-                buildClient.getBuildWorkItemsRefs(settings.projectId, Number(currentArtifact.definitionReference.version.id), settings.workitemLimit)
+                buildClient.getBuildWorkItemsRefs(settings.projectId, Number(currentArtifact.definitionReference.version.id), settings.workitemLimit);
             }
         }
         return workItemRefs;


### PR DESCRIPTION
This PR adds code to support release pipelines with multiple artifacts. #62 

It compares the current releases' artifact versions with the last successful run and gets the list of work items in between these two builds.

Full disclosure: I'm not a TS/JS Dev so please forgive my mistakes and I also could not test this yet as I don't have an easy way to do so. 

I will comment once I can see if this fixed the issue for my pipelines in a few days.