### PR TITLE
Update WorkItemUpdater.ts

### DIFF
--- a/src/WorkItemUpdater.ts
+++ b/src/WorkItemUpdater.ts
@@ -220,6 +220,9 @@ async function getBuildOrReleaseWorkItemsRefs(vstsWebApi: WebApi, settings: Sett
 }
 
 function pushWorkItemsRefs(workItemRefs: ResourceRef[], workItemRefsToAdd: ResourceRef[]) {
+    if (typeof workItemRefsToAdd == "undefined") {
+        workItemRefsToAdd = [];
+    } 
     workItemRefsToAdd.forEach((workItemRef: ResourceRef) => {
         workItemRefs.push({
             id: workItemRef.id.toString(),


### PR DESCRIPTION
Added a null check for workItemRefsToAdd since the for each breaks if the build or release does not have any Work items associated. if null initialized to an empty array.

![image](https://github.com/user-attachments/assets/e74f5fc5-d565-4e31-b7a6-5333066d63e7)
