### PR TITLE
fix: support spaces between commas of worktypes

### DIFF
--- a/src/WorkItemUpdater.ts
+++ b/src/WorkItemUpdater.ts
@@ -238,8 +238,8 @@ async function getQueryWorkItemsRefs(workItemTrackingClient: IWorkItemTrackingAp
 
 async function updateWorkItem(workItemTrackingClient: IWorkItemTrackingApi, workItem: WorkItem, settings: Settings): Promise<boolean> {
     tl.debug('Updating  WorkItem: ' + workItem.id);
-    if (settings.workItemType.split(',').indexOf(workItem.fields['System.WorkItemType']) >= 0) {
-        if (settings.workItemCurrentState && settings.workItemCurrentState !== '' && settings.workItemCurrentState.split(',').indexOf(workItem.fields['System.State']) === -1) {
+    if (settings.workItemType.split(',').map(s => s.trim()).indexOf(workItem.fields['System.WorkItemType']) >= 0) {
+        if (settings.workItemCurrentState && settings.workItemCurrentState !== '' && settings.workItemCurrentState.split(',').map(s => s.trim()).indexOf(workItem.fields['System.State']) === -1) {
             console.log('Skipped WorkItem: ' + workItem.id + ' State: "' + workItem.fields['System.State'] + '" => Only updating if state in "' + settings.workItemCurrentState) + '"';
             return false;
         }


### PR DESCRIPTION
Additional support for spaces after commas in workItemType.

Currently the workItemType `Bug, Story` doesn't work (`Bug,Story` does).

This simply trims after splitting.

![image](https://github.com/user-attachments/assets/453de632-3937-435d-8370-86f1fc80ac6e)

For reference: [Link To Playground](https://www.typescriptlang.org/play/?#code/G4QwTgBA7g9mDWBJALgUwLYBUCeAHVEAvBAEQBCArgOYA0EAysnNiQFCiTJ6oDOR0cJGizcAdD1wAbAJbIAFAHIaCgJQBuVqwDGMAHY8Yk1KMkwqcrvh6jpugCaoAHgHkAZnPLUSKiAD5iAAwq2noGRiZmFtzWtg4u7iSMzN5+gcHs4BCWvPywCCgYOPjiUrKKyiqi6CC4cnyEvhDWyGDS6HIq6po6+obGpubZMfZObh6UVCn+EEEhveEDUVY2I-EeSWAsPtNBQA)